### PR TITLE
Remove audible.com from Microsoft blocklist

### DIFF
--- a/corporations/microsoft/all
+++ b/corporations/microsoft/all
@@ -12,7 +12,6 @@
 0.0.0.0 aspnetcdn.com
 0.0.0.0 atdmt.com
 0.0.0.0 atlassolutions.com
-0.0.0.0 audible.com
 0.0.0.0 azure.com
 0.0.0.0 azuredns-cloud.net
 0.0.0.0 azure.net


### PR DESCRIPTION
Audible is an Amazon company so it doesn't really belong in the Microsoft blocklist.