### PR TITLE
remove duck.com from google lists

### DIFF
--- a/corporations/google/non_localized
+++ b/corporations/google/non_localized
@@ -15,7 +15,6 @@
 0.0.0.0  com.google        # elgooG
 0.0.0.0  domains.google      # Google Domains
 0.0.0.0  doubleclick.com     # DoubleClick
-0.0.0.0  duck.com        # Google
 0.0.0.0  feedburner.com      # FeedBurner
 0.0.0.0  firehunt.com      # Google
 0.0.0.0  foofle.com        # Google

--- a/corporations/google/non_localized.easylist
+++ b/corporations/google/non_localized.easylist
@@ -50,9 +50,6 @@
 ||doubleclick.com^
 ||doubleclick.com^$popup
 ||doubleclick.com^$third-party
-||duck.com^
-||duck.com^$popup
-||duck.com^$third-party
 ||feedburner.com^
 ||feedburner.com^$popup
 ||feedburner.com^$third-party


### PR DESCRIPTION
`duck.com` now belongs to `Duck Duck Go, Inc.`

Fix for #52